### PR TITLE
Update to use HIBP's anonymous endpoint

### DIFF
--- a/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
+++ b/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
@@ -48,27 +48,21 @@ namespace HaveIBeenPwnedValidator
             if (response.IsSuccessStatusCode)
             {
                 // Response was a success. Check to see if the SAH1 suffix is in the response body.
-                var isPwned = (await response.Content.ReadAsStringAsync()).Contains(sha1Suffix);
+                var content = await response.Content.ReadAsStringAsync();
+                var isPwned = content.Contains(sha1Suffix);
                 if (isPwned)
                 {
-                    _logger.LogDebug("HaveIBeenPwned API indicate the password has been pwned");
+                    _logger.LogDebug("HaveIBeenPwned API indicates the password has been pwned");
                     return true;
                 }
                 else
                 {
-                    _logger.LogDebug("HaveIBeenPwned API indicate the password has not been pwned");
+                    _logger.LogDebug("HaveIBeenPwned API indicates the password has not been pwned");
+                    return false;
                 }
             }
 
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                _logger.LogDebug("HaveIBeenPwned API indicate the password has not been pwned");
-            }
-            else
-            {
-                _logger.LogWarning("Unexepected response from API: {StatusCode}", response.StatusCode);
-            }
-
+            _logger.LogWarning("Unexepected response from API: {StatusCode}", response.StatusCode);
             return false;
         }
 

--- a/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
+++ b/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
@@ -36,9 +36,6 @@ namespace HaveIBeenPwnedValidator
             var sha1Prefix = sha1Password.Substring(0, 5);
             var sha1Suffix = sha1Password.Substring(5);
 
-            var formContent = new FormUrlEncodedContent(
-                new Dictionary<string, string> { { "Password", sha1Password } });
-
             var msg = new HttpRequestMessage(HttpMethod.Get, string.Format("{0}/{1}", _options.ApiUrl, sha1Prefix));
 
             var response = await _client.SendAsync(msg);

--- a/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
+++ b/src/HaveIBeenPwnedValidator/PwnedPasswordApiService.cs
@@ -36,7 +36,7 @@ namespace HaveIBeenPwnedValidator
             var sha1Prefix = sha1Password.Substring(0, 5);
             var sha1Suffix = sha1Password.Substring(5);
 
-            var msg = new HttpRequestMessage(HttpMethod.Get, string.Format("{0}/{1}", _options.ApiUrl, sha1Prefix));
+            var msg = new HttpRequestMessage(HttpMethod.Get, $"{_options.ApiUrl}/{sha1Prefix}");
 
             var response = await _client.SendAsync(msg);
 

--- a/src/HaveIBeenPwnedValidator/PwnedPasswordApiServiceOptions.cs
+++ b/src/HaveIBeenPwnedValidator/PwnedPasswordApiServiceOptions.cs
@@ -13,9 +13,9 @@
 
         /// <summary>
         /// The full URL of the API to call
-        /// Defaults to https://api.pwnedpasswords.com/range/
+        /// Defaults to https://api.pwnedpasswords.com/range
         /// </summary>
-        public string ApiUrl { get; set; } = "https://api.pwnedpasswords.com/range/";
+        public string ApiUrl { get; set; } = "https://api.pwnedpasswords.com/range";
 
         /// <summary>
         /// The minimum time between requests to the API in milliseconds

--- a/src/HaveIBeenPwnedValidator/PwnedPasswordApiServiceOptions.cs
+++ b/src/HaveIBeenPwnedValidator/PwnedPasswordApiServiceOptions.cs
@@ -13,9 +13,9 @@
 
         /// <summary>
         /// The full URL of the API to call
-        /// Defaults to https://haveibeenpwned.com/api/v2/pwnedpassword
+        /// Defaults to https://api.pwnedpasswords.com/range/
         /// </summary>
-        public string ApiUrl { get; set; } = "https://haveibeenpwned.com/api/v2/pwnedpassword";
+        public string ApiUrl { get; set; } = "https://api.pwnedpasswords.com/range/";
 
         /// <summary>
         /// The minimum time between requests to the API in milliseconds


### PR DESCRIPTION
Troy has disabled the ability to search by password. This PR changes the pwned password API check to use the [anonymous endpoint Troy has set up](https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange). This change is desirable because: 

- The full password to be checked is no longer transferred across the wire.
- The new endpoint has no rate limiting.