### PR TITLE
Simplify internal API

### DIFF
--- a/src/PwnedPasswords.Client/PwnedPasswordsClient.cs
+++ b/src/PwnedPasswords.Client/PwnedPasswordsClient.cs
@@ -62,7 +62,7 @@ namespace PwnedPasswords.Client
             return false;
         }
 
-        internal static async Task<int> Contains(HttpContent content, string sha1Suffix)
+        internal static async Task<long> Contains(HttpContent content, string sha1Suffix)
         {
             using (var streamReader = new StreamReader(await content.ReadAsStreamAsync()))
             {
@@ -72,7 +72,7 @@ namespace PwnedPasswords.Client
                     var segments = line.Split(':');
                     if (segments.Length == 2
                         && string.Equals(segments[0], sha1Suffix, StringComparison.OrdinalIgnoreCase)
-                        && int.TryParse(segments[1], out var count))
+                        && long.TryParse(segments[1], out var count))
                     {
                         return count;
                     }


### PR DESCRIPTION
As mentioned by @SeanFarrow on Twitter:

> I wonder whether we have missed a trick with the pwned password validator client, we currently return a boolean and the number of instances the password was pwned, should we not just return the number of instances and 0 if the password was not found?

It's an internal API, so doesn't really matter, but I agree!