### PR TITLE
Allow setting the minimum password frequency to consider a password pwned

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+You can also choose the minimum number of times a password must have appeared in a breach for it to be considered "pwned". So for example, if you only want to consider passwords that have appeared 20 times as pwned you can use the overload on `AddPwnedPasswordHttpClient()`:
+
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddPwnedPasswordHttpClient(minimumFrequencyToConsiderPwned: 20);
+}
+```
+
+You can also configure this using the standard Options pattern in ASP.NET Core, for example by loading the required value from a JSON value.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddPwnedPasswordHttpClient();
+    services.Configure<PwnedPasswordsClientOptions>(Configuration.GetSection("PwnedPasswords"));
+}
+```
+
 ## PwnedPasswords.Validator
 
 _PwnedPasswords.Validator_ contains an implementation of an [ASP.NET Core Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity) `IPasswordValidator` that verifies the provided password has not been exposed in a known security breach.
@@ -97,6 +117,20 @@ public void ConfigureServices(IServiceCollection services)
         .AddPwnedPasswordValidator<IdentityUser>(); // add the validator
 
     // other configuration
+}
+```
+
+As for the `PwnedPasswordsClient` library, you can customize the minimum number of times a password must have appeared in a breach for it to be considered invalid by the validator. For example:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddDefaultIdentity<IdentityUser>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddPwnedPasswordValidator<IdentityUser>(); // add the validator
+
+    // set the minimum password to consider the password pwned
+    services.Configure<PwnedPasswordsClientOptions>(Configuration.GetSection("PwnedPasswords"));
 }
 ```
 

--- a/samples/PwnedPasswords.Sample/Startup.cs
+++ b/samples/PwnedPasswords.Sample/Startup.cs
@@ -34,7 +34,7 @@ namespace PwnedPasswords.Sample
 
             // Explicitly configure the PwnedPassword client to timeout after 2 seconds, and retry 3 times
             // The pwnedpassword API achieves 99% percentile of <1s, so this should be sufficient!
-            services.AddPwnedPasswordHttpClient()
+            services.AddPwnedPasswordHttpClient(minimumFrequencyToConsiderPwned: 20)
                   .AddTransientHttpErrorPolicy(p => p.RetryAsync(3))
                   .AddPolicyHandler(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(2)));
 

--- a/src/PwnedPasswords.Client/PwnedPasswordClientOptions.cs
+++ b/src/PwnedPasswords.Client/PwnedPasswordClientOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace PwnedPasswords.Client
+{
+    /// <summary>
+    /// Options for configuring the <see cref="IPwnedPasswordsClient"/>
+    /// </summary>
+    public class PwnedPasswordsClientOptions
+    {
+        /// <summary>
+        /// The minimum frequency to consider a password to be Pwned.
+        /// For example, setting this to 20 means only PwnedPasswords seen 20 times
+        /// or more will be considered Pwned. Defaults to 1 (so all pwned passwords are considered)
+        /// </summary>
+        public int MinimumFrequencyToConsiderPwned { get; set; } = 1;
+    }
+}

--- a/src/PwnedPasswords.Client/PwnedPasswords.Client.csproj
+++ b/src/PwnedPasswords.Client/PwnedPasswords.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A typed HttpClient for use with Troy Hunt's HaveIBeenPwned Pwned Passwords service: https://haveibeenpwned.com/Passwords</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Andrew Lock</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/PwnedPasswords.Client/PwnedPasswordsClient.cs
+++ b/src/PwnedPasswords.Client/PwnedPasswordsClient.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace PwnedPasswords.Client
 {
@@ -16,16 +17,18 @@ namespace PwnedPasswords.Client
         /// </summary>
         public const string DefaultName = "PwnedPasswordsClient";
 
-        HttpClient _client;
-        ILogger<PwnedPasswordsClient> _logger;
+        readonly HttpClient _client;
+        readonly ILogger<PwnedPasswordsClient> _logger;
+        readonly PwnedPasswordsClientOptions _options;
 
         /// <summary>
         /// Create a new instance of <see cref="PwnedPasswordsClient"/>
         /// </summary>
-        public PwnedPasswordsClient(HttpClient client, ILogger<PwnedPasswordsClient> logger)
+        public PwnedPasswordsClient(HttpClient client, ILogger<PwnedPasswordsClient> logger, IOptions<PwnedPasswordsClientOptions> options)
         {
             _client = client;
             _logger = logger;
+            _options = options.Value;
         }
 
         /// <inheritdoc />
@@ -42,7 +45,7 @@ namespace PwnedPasswords.Client
                 {
                     // Response was a success. Check to see if the SAH1 suffix is in the response body.
                     var frequency = await Contains(response.Content, sha1Suffix);
-                    var isPwned = (frequency > 0);
+                    var isPwned = (frequency >= _options.MinimumFrequencyToConsiderPwned);
                     if (isPwned)
                     {
                         _logger.LogDebug("HaveIBeenPwned API indicates the password has been pwned");

--- a/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
+++ b/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        private static readonly Action<HttpClient> DefaultConfigureClientFunction = client =>
+        {
+            client.BaseAddress = new Uri("https://api.pwnedpasswords.com");
+            client.DefaultRequestHeaders.Add("User-Agent", nameof(PwnedPasswordsClient));
+        };
 
         /// <summary>
         /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/>
@@ -117,7 +122,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services)
         {
-            return services.AddPwnedPasswordHttpClient(1);
+            return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, DefaultConfigureClientFunction);
         }
 
         /// <summary>
@@ -139,11 +144,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, int minimumFrequencyToConsiderPwned)
         {
-            return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, client =>
-            {
-                client.BaseAddress = new Uri("https://api.pwnedpasswords.com");
-                client.DefaultRequestHeaders.Add("User-Agent", nameof(PwnedPasswordsClient));
-            }, opts => opts.MinimumFrequencyToConsiderPwned = minimumFrequencyToConsiderPwned);
+            return services.AddPwnedPasswordHttpClient(DefaultConfigureClientFunction,
+                opts => opts.MinimumFrequencyToConsiderPwned = minimumFrequencyToConsiderPwned);
         }
     }
 }

--- a/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
+++ b/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
-        /// <param name="configureHttpClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
+        /// <param name="configureClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
         /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
         /// <remarks>
         ///  <see cref="HttpClient"/> instances that apply the provided configuration can
@@ -26,9 +26,9 @@ namespace Microsoft.Extensions.DependencyInjection
         ///  can be retrieved from <see cref="System.IServiceProvider.GetService(System.Type)"/> (and related
         ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
         /// </remarks>
-        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name, Action<HttpClient> configureHttpClient)
+        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name, Action<HttpClient> configureClient)
         {
-            return services.AddPwnedPasswordHttpClient(name, configureHttpClient, options => { });
+            return services.AddPwnedPasswordHttpClient(name, configureClient, options => { });
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
-        /// <param name="configureHttpClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
+        /// <param name="configureClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
         /// <param name="configureOptions">A delegate that is used to configure the <see cref="PwnedPasswordsClientOptions"/></param>
         /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
         /// <remarks>
@@ -49,10 +49,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
         /// </remarks>
         public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name,
-            Action<HttpClient> configureHttpClient, Action<PwnedPasswordsClientOptions> configureOptions)
+            Action<HttpClient> configureClient, Action<PwnedPasswordsClientOptions> configureOptions)
         {
             services.Configure(configureOptions);
-            return services.AddHttpClient<IPwnedPasswordsClient, PwnedPasswordsClient>(name, configureHttpClient);
+            return services.AddHttpClient<IPwnedPasswordsClient, PwnedPasswordsClient>(name, configureClient);
         }
 
         /// <summary>

--- a/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
+++ b/src/PwnedPasswords.Client/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
-        /// <param name="configureClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
+        /// <param name="configureHttpClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
         /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
         /// <remarks>
         ///  <see cref="HttpClient"/> instances that apply the provided configuration can
@@ -26,9 +26,33 @@ namespace Microsoft.Extensions.DependencyInjection
         ///  can be retrieved from <see cref="System.IServiceProvider.GetService(System.Type)"/> (and related
         ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
         /// </remarks>
-        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name, Action<HttpClient> configureClient)
+        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name, Action<HttpClient> configureHttpClient)
         {
-            return services.AddHttpClient<IPwnedPasswordsClient, PwnedPasswordsClient>(name, configureClient);
+            return services.AddPwnedPasswordHttpClient(name, configureHttpClient, options => { });
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/>
+        /// and configures a binding between the <see cref="IPwnedPasswordsClient"/> and a named <see cref="HttpClient"/>
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
+        /// <param name="configureHttpClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
+        /// <param name="configureOptions">A delegate that is used to configure the <see cref="PwnedPasswordsClientOptions"/></param>
+        /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
+        /// <remarks>
+        ///  <see cref="HttpClient"/> instances that apply the provided configuration can
+        ///  be retrieved using <see cref="IHttpClientFactory.CreateClient(System.String)"/>
+        ///  and providing the matching name.
+        ///  <see cref="IPwnedPasswordsClient"/> instances constructed with the appropriate <see cref="HttpClient"/>
+        ///  can be retrieved from <see cref="System.IServiceProvider.GetService(System.Type)"/> (and related
+        ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
+        /// </remarks>
+        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, string name,
+            Action<HttpClient> configureHttpClient, Action<PwnedPasswordsClientOptions> configureOptions)
+        {
+            services.Configure(configureOptions);
+            return services.AddHttpClient<IPwnedPasswordsClient, PwnedPasswordsClient>(name, configureHttpClient);
         }
 
         /// <summary>
@@ -49,7 +73,30 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, Action<HttpClient> configureClient)
         {
-            return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, configureClient);
+            return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, configureClient, options => { });
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/>
+        /// and configures a binding between the <see cref="IPwnedPasswordsClient"/> and an <see cref="HttpClient"/>
+        /// named <see cref="PwnedPasswordsClient.DefaultName"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureClient">A delegate that is used to configure the <see cref="HttpClient"/> used by <see cref="IPwnedPasswordsClient"/></param>
+        /// <param name="configureOptions">A delegate that is used to configure the <see cref="PwnedPasswordsClientOptions"/></param>
+        /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
+        /// <remarks>
+        ///  <see cref="HttpClient"/> instances that apply the provided configuration can
+        ///  be retrieved using <see cref="IHttpClientFactory.CreateClient(System.String)"/>
+        ///  and providing the matching name.
+        ///  <see cref="IPwnedPasswordsClient"/> instances constructed with the appropriate <see cref="HttpClient"/>
+        ///  can be retrieved from <see cref="System.IServiceProvider.GetService(System.Type)"/> (and related
+        ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
+        /// </remarks>
+        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, 
+            Action<HttpClient> configureClient, Action<PwnedPasswordsClientOptions> configureOptions)
+        {
+            return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, configureClient, configureOptions);
         }
 
         /// <summary>
@@ -70,11 +117,33 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services)
         {
+            return services.AddPwnedPasswordHttpClient(1);
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/>
+        /// and configures a binding between the <see cref="IPwnedPasswordsClient"/> and an <see cref="HttpClient"/>
+        /// named <see cref="PwnedPasswordsClient.DefaultName"/> to use the public HaveIBeenPwned API 
+        /// at "https://api.pwnedpasswords.com"
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="minimumFrequencyToConsiderPwned">The minimum frequency to consider a password to be Pwned.  For example, setting this to 20 means only PwnedPasswords seen 20 times or more are considered pwned.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/>that can be used to configure the client.</returns>
+        /// <remarks>
+        ///  <see cref="HttpClient"/> instances that apply the provided configuration can
+        ///  be retrieved using <see cref="IHttpClientFactory.CreateClient(System.String)"/>
+        ///  and providing the matching name.
+        ///  <see cref="IPwnedPasswordsClient"/> instances constructed with the appropriate <see cref="HttpClient"/>
+        ///  can be retrieved from <see cref="System.IServiceProvider.GetService(System.Type)"/> (and related
+        ///  methods) by providing <see cref="IPwnedPasswordsClient"/> as the service type.
+        /// </remarks>
+        public static IHttpClientBuilder AddPwnedPasswordHttpClient(this IServiceCollection services, int minimumFrequencyToConsiderPwned)
+        {
             return services.AddPwnedPasswordHttpClient(PwnedPasswordsClient.DefaultName, client =>
             {
                 client.BaseAddress = new Uri("https://api.pwnedpasswords.com");
                 client.DefaultRequestHeaders.Add("User-Agent", nameof(PwnedPasswordsClient));
-            });
+            }, opts => opts.MinimumFrequencyToConsiderPwned = minimumFrequencyToConsiderPwned);
         }
     }
 }

--- a/src/PwnedPasswords.Validator/IdentityBuilderExtensions.cs
+++ b/src/PwnedPasswords.Validator/IdentityBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IdentityBuilder builder, Action<PwnedPasswordValidatorOptions> configure)
             where TUser : class
         {
-            return builder.AddPwnedPasswordValidator<TUser>(configure: opts => { }, configureClient: opts => { });
+            return builder.AddPwnedPasswordValidator<TUser>(configure, configureClient: opts => { });
         }
 
         /// <summary>

--- a/src/PwnedPasswords.Validator/PwnedPasswordValidatorOptions.cs
+++ b/src/PwnedPasswords.Validator/PwnedPasswordValidatorOptions.cs
@@ -1,11 +1,9 @@
-﻿using PwnedPasswords.Client;
-
-namespace PwnedPasswords.Validator
+﻿namespace PwnedPasswords.Validator
 {
     /// <summary>
     /// Options for configuring the <see cref="PwnedPasswordValidator{TUser}"/>
     /// </summary>
-    public class PwnedPasswordValidatorOptions: PwnedPasswordsClientOptions
+    public class PwnedPasswordValidatorOptions
     {
         /// <summary>
         /// The error message to display when a breached password is used.

--- a/src/PwnedPasswords.Validator/PwnedPasswordValidatorOptions.cs
+++ b/src/PwnedPasswords.Validator/PwnedPasswordValidatorOptions.cs
@@ -1,9 +1,11 @@
-﻿namespace PwnedPasswords.Validator
+﻿using PwnedPasswords.Client;
+
+namespace PwnedPasswords.Validator
 {
     /// <summary>
     /// Options for configuring the <see cref="PwnedPasswordValidator{TUser}"/>
     /// </summary>
-    public class PwnedPasswordValidatorOptions
+    public class PwnedPasswordValidatorOptions: PwnedPasswordsClientOptions
     {
         /// <summary>
         /// The error message to display when a breached password is used.

--- a/src/PwnedPasswords.Validator/PwnedPasswords.Validator.csproj
+++ b/src/PwnedPasswords.Validator/PwnedPasswords.Validator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>An Implementation of ASP.NET Core Identity IPasswordValidator that verifies the provided password has not been pwned, as defined by Troy Hunt's HaveIBeenPwned service: https://haveibeenpwned.com/Passwords</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Andrew Lock</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/PwnedPasswords.Client.Test/HaveIBeenPwnedClientTests.cs
+++ b/test/PwnedPasswords.Client.Test/HaveIBeenPwnedClientTests.cs
@@ -32,17 +32,30 @@ namespace PwnedPasswords.Client.Test
             Assert.True(isPwned, "Checking for Pwned password should return true");
         }
 
-        private static PwnedPasswordsClient GetClient()
+        [Fact, Trait("Category", "Integration")] // don't run it automatically
+        public async Task HasPasswordBeenPwned_WhenWeakPasswordButUnderThresholdViews_ReturnsFalse()
+        {
+            PwnedPasswordsClient service = GetClient(5000);
+
+            var pwnedPassword = "Password1!";
+
+            var isPwned = await service.HasPasswordBeenPwned(pwnedPassword);
+
+            Assert.True(isPwned, "Checking for Pwned password should return true");
+        }
+
+        private static PwnedPasswordsClient GetClient(int minimumFrequencyToConsiderPwned = 1)
         {
             var services = new ServiceCollection();
-            services.AddPwnedPasswordHttpClient();
+            services.AddPwnedPasswordHttpClient(minimumFrequencyToConsiderPwned);
             var provider = services.BuildServiceProvider();
 
             //all called in one method to easily enforce timout
 
             var service = new PwnedPasswordsClient(
                 provider.GetService<IHttpClientFactory>().CreateClient(PwnedPasswordsClient.DefaultName),
-                MockHelpers.StubLogger<PwnedPasswordsClient>());
+                MockHelpers.StubLogger<PwnedPasswordsClient>(),
+                MockHelpers.Options<PwnedPasswordsClientOptions>());
             return service;
         }
     }

--- a/test/PwnedPasswords.Client.Test/MockHelpers.cs
+++ b/test/PwnedPasswords.Client.Test/MockHelpers.cs
@@ -54,6 +54,7 @@ namespace PwnedPasswords.Client.Test
             stub.SetupGet(x => x.Value).Returns(options);
             return stub.Object;
         }
+
         public static IOptions<T> Options<T>() where T : class, new()
         {
             return Options(new T());

--- a/test/PwnedPasswords.Client.Test/MockHelpers.cs
+++ b/test/PwnedPasswords.Client.Test/MockHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace PwnedPasswords.Client.Test
@@ -45,6 +46,17 @@ namespace PwnedPasswords.Client.Test
         {
             var stub = new Mock<ILogger<T>>();
             return stub.Object;
+        }
+
+        public static IOptions<T> Options<T>(T options) where T : class, new()
+        {
+            var stub = new Mock<IOptions<T>>();
+            stub.SetupGet(x => x.Value).Returns(options);
+            return stub.Object;
+        }
+        public static IOptions<T> Options<T>() where T : class, new()
+        {
+            return Options(new T());
         }
     }
 }


### PR DESCRIPTION
Added additional options configuration object for PwnedPasswordsClient for this reason. Make things a bit messy but it's probably the only reasonable option (+ might need to add more options down the line)

Fixes #8